### PR TITLE
Chore: change metadata and contact

### DIFF
--- a/src/lib/components/widgets/home.svelte
+++ b/src/lib/components/widgets/home.svelte
@@ -218,14 +218,14 @@
 			> ✨.</span
 		>
 		<span>
-			Jika terdapat kendala mengenai website ini, silahkan hubungi saya melalui email
-			<a href="mailto:kherr.riil@gmail.com" class="text-blue-500 hover:underline">
-				kherr.riil@gmail.com
+			Jika terdapat kendala mengenai website ini, silahkan submit issue melalui
+			<a href="https://github.com/savioruz/smrv2/issues" class="text-blue-500 hover:underline">
+				GitHub.
 			</a>
-			atau
+			atau bisa langsung hubungi saya melalui
 			<a href="https://t.me/savioruz" class="text-blue-500 hover:underline">Telegram.</a>
 		</span>
-		<span>Terima kasih ! 🙂</span>
+		<span>Terima kasih sudah menggunakan website ini! 🙂</span>
 	</div>
 </Marquee>
 <Root class="flex min-h-[calc(100vh-10rem)] flex-col gap-8">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <svelte:head>
-	<title>{siteConfig.name} - Personal Website</title>
+	<title>{siteConfig.name}</title>
 	<meta name="description" content={siteConfig.description} />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<meta charset="utf-8" />
@@ -17,7 +17,7 @@
 	<meta name="keywords" content={siteConfig.keywords} />
 	<meta name="author" content={siteConfig.name} />
 
-	<meta property="og:title" content="{siteConfig.name} - Personal Website" />
+	<meta property="og:title" content="{siteConfig.name}" />
 	<meta property="og:description" content={siteConfig.description} />
 	<meta property="og:type" content="website" />
 	<meta property="og:locale" content="en_US" />


### PR DESCRIPTION
This pull request includes updates to the contact information and the title metadata of the website. The changes improve the user experience by providing more relevant contact options and simplifying the title metadata.

Updates to contact information:

* [`src/lib/components/widgets/home.svelte`](diffhunk://#diff-618b7d83235b0abc9764858e298d20b74edce9d043e46de5c53b306ea9c56939L221-R228): Changed the contact method from email to GitHub issues and updated the message to thank users for using the website.

Updates to title metadata:

* [`src/routes/+layout.svelte`](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dL12-R20): Simplified the title and Open Graph title metadata by removing the "Personal Website" suffix.